### PR TITLE
New Feature: Prioritizing localhost over remote hosts when sending requests to KES instances

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.20.7
+        go-version: 1.21.1
         check-latest: true
     - name: Check out code
       uses: actions/checkout@v3
@@ -40,7 +40,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.20.7
+        go-version: 1.21.1
         check-latest: true
     - name: Check out code
       uses: actions/checkout@v3
@@ -56,7 +56,7 @@ jobs:
       uses: actions/checkout@v3
     - uses: actions/setup-go@v3
       with:
-        go-version: 1.20.7
+        go-version: 1.21.1
         check-latest: true
     - name: Get govulncheck
       run: go install golang.org/x/vuln/cmd/govulncheck@latest

--- a/client.go
+++ b/client.go
@@ -139,7 +139,7 @@ func (c *Client) Version(ctx context.Context) (string, error) {
 	c.init.Do(c.initLoadBalancer)
 
 	client := retry(c.HTTPClient)
-	resp, err := c.lb.Send(ctx, &client, Method, c.Endpoints, APIPath, nil)
+	resp, err := c.lb.Send(ctx, &client, Method, APIPath, nil)
 	if err != nil {
 		return "", err
 	}
@@ -173,7 +173,7 @@ func (c *Client) IsReady(ctx context.Context) (bool, error) {
 	c.init.Do(c.initLoadBalancer)
 
 	client := retry(c.HTTPClient)
-	resp, err := c.lb.Send(ctx, &client, Method, c.Endpoints, APIPath, nil)
+	resp, err := c.lb.Send(ctx, &client, Method, APIPath, nil)
 	if err != nil {
 		return false, err
 	}
@@ -193,7 +193,7 @@ func (c *Client) Status(ctx context.Context) (State, error) {
 	c.init.Do(c.initLoadBalancer)
 
 	client := retry(c.HTTPClient)
-	resp, err := c.lb.Send(ctx, &client, Method, c.Endpoints, APIPath, nil)
+	resp, err := c.lb.Send(ctx, &client, Method, APIPath, nil)
 	if err != nil {
 		return State{}, err
 	}
@@ -226,7 +226,7 @@ func (c *Client) APIs(ctx context.Context) ([]API, error) {
 	c.init.Do(c.initLoadBalancer)
 
 	client := retry(c.HTTPClient)
-	resp, err := c.lb.Send(ctx, &client, Method, c.Endpoints, APIPath, nil)
+	resp, err := c.lb.Send(ctx, &client, Method, APIPath, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -280,7 +280,7 @@ func (c *Client) ExpandCluster(ctx context.Context, endpoint string) error {
 	}
 
 	client := retry(c.HTTPClient)
-	resp, err := c.lb.Send(ctx, &client, Method, c.Endpoints, APIPath, bytes.NewReader(body))
+	resp, err := c.lb.Send(ctx, &client, Method, APIPath, bytes.NewReader(body))
 	if err != nil {
 		return err
 	}
@@ -307,7 +307,7 @@ func (c *Client) DescribeCluster(ctx context.Context) (*ClusterInfo, error) {
 	c.init.Do(c.initLoadBalancer)
 
 	client := retry(c.HTTPClient)
-	resp, err := c.lb.Send(ctx, &client, Method, c.Endpoints, APIPath, nil)
+	resp, err := c.lb.Send(ctx, &client, Method, APIPath, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -347,7 +347,7 @@ func (c *Client) ShrinkCluster(ctx context.Context, endpoint string) error {
 	}
 
 	client := retry(c.HTTPClient)
-	resp, err := c.lb.Send(ctx, &client, Method, c.Endpoints, APIPath, bytes.NewReader(body))
+	resp, err := c.lb.Send(ctx, &client, Method, APIPath, bytes.NewReader(body))
 	if err != nil {
 		return err
 	}
@@ -374,7 +374,7 @@ func (c *Client) CreateEnclave(ctx context.Context, name string) error {
 	c.init.Do(c.initLoadBalancer)
 
 	client := retry(c.HTTPClient)
-	resp, err := c.lb.Send(ctx, &client, Method, c.Endpoints, join(APIPath, name), nil)
+	resp, err := c.lb.Send(ctx, &client, Method, join(APIPath, name), nil)
 	if err != nil {
 		return err
 	}
@@ -407,7 +407,7 @@ func (c *Client) DescribeEnclave(ctx context.Context, name string) (*EnclaveInfo
 	c.init.Do(c.initLoadBalancer)
 
 	client := retry(c.HTTPClient)
-	resp, err := c.lb.Send(ctx, &client, Method, c.Endpoints, join(APIPath, name), nil)
+	resp, err := c.lb.Send(ctx, &client, Method, join(APIPath, name), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -450,7 +450,7 @@ func (c *Client) ListEnclaves(ctx context.Context, prefix string, n int) ([]stri
 	c.init.Do(c.initLoadBalancer)
 
 	client := retry(c.HTTPClient)
-	resp, err := c.lb.Send(ctx, &client, Method, c.Endpoints, join(APIPath, prefix), nil)
+	resp, err := c.lb.Send(ctx, &client, Method, join(APIPath, prefix), nil)
 	if err != nil {
 		return nil, "", err
 	}
@@ -484,7 +484,7 @@ func (c *Client) DeleteEnclave(ctx context.Context, name string) error {
 	c.init.Do(c.initLoadBalancer)
 
 	client := retry(c.HTTPClient)
-	resp, err := c.lb.Send(ctx, &client, Method, c.Endpoints, join(APIPath, name), nil)
+	resp, err := c.lb.Send(ctx, &client, Method, join(APIPath, name), nil)
 	if err != nil {
 		return err
 	}
@@ -837,7 +837,7 @@ func (c *Client) AuditLog(ctx context.Context) (*AuditStream, error) {
 	c.init.Do(c.initLoadBalancer)
 
 	client := retry(c.HTTPClient)
-	resp, err := c.lb.Send(ctx, &client, Method, c.Endpoints, APIPath, nil)
+	resp, err := c.lb.Send(ctx, &client, Method, APIPath, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -863,7 +863,7 @@ func (c *Client) ErrorLog(ctx context.Context) (*ErrorStream, error) {
 	c.init.Do(c.initLoadBalancer)
 
 	client := retry(c.HTTPClient)
-	resp, err := c.lb.Send(ctx, &client, Method, c.Endpoints, APIPath, nil)
+	resp, err := c.lb.Send(ctx, &client, Method, APIPath, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -888,7 +888,8 @@ func (c *Client) Metrics(ctx context.Context) (Metric, error) {
 
 func (c *Client) initLoadBalancer() {
 	if c.lb == nil {
-		c.lb = &loadBalancer{endpoints: map[string]time.Time{}}
+		c.lb = newLoadBalancer("")
+		c.lb.prepareLoadBalancer(c.Endpoints)
 	}
 }
 

--- a/enclave.go
+++ b/enclave.go
@@ -126,7 +126,7 @@ func (e *Enclave) Metrics(ctx context.Context) (Metric, error) {
 	e.init.Do(e.initLoadBalancer)
 
 	client := retry(e.HTTPClient)
-	resp, err := e.lb.Send(ctx, &client, Method, e.Endpoints, APIPath, nil)
+	resp, err := e.lb.Send(ctx, &client, Method, APIPath, nil)
 	if err != nil {
 		return Metric{}, err
 	}
@@ -244,7 +244,7 @@ func (e *Enclave) CreateKey(ctx context.Context, name string) error {
 	e.init.Do(e.initLoadBalancer)
 
 	client := retry(e.HTTPClient)
-	resp, err := e.lb.Send(ctx, &client, Method, e.Endpoints, join(APIPath, name), nil)
+	resp, err := e.lb.Send(ctx, &client, Method, join(APIPath, name), nil)
 	if err != nil {
 		return err
 	}
@@ -278,7 +278,7 @@ func (e *Enclave) ImportKey(ctx context.Context, name string, req *ImportKeyRequ
 	}
 
 	client := retry(e.HTTPClient)
-	resp, err := e.lb.Send(ctx, &client, Method, e.Endpoints, join(APIPath, name), bytes.NewReader(body), withHeader("Content-Type", "application/json"))
+	resp, err := e.lb.Send(ctx, &client, Method, join(APIPath, name), bytes.NewReader(body), withHeader("Content-Type", "application/json"))
 	if err != nil {
 		return err
 	}
@@ -308,7 +308,7 @@ func (e *Enclave) DescribeKey(ctx context.Context, name string) (*KeyInfo, error
 	e.init.Do(e.initLoadBalancer)
 
 	client := retry(e.HTTPClient)
-	resp, err := e.lb.Send(ctx, &client, Method, e.Endpoints, join(APIPath, name), nil)
+	resp, err := e.lb.Send(ctx, &client, Method, join(APIPath, name), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -341,7 +341,7 @@ func (e *Enclave) DeleteKey(ctx context.Context, name string) error {
 	e.init.Do(e.initLoadBalancer)
 
 	client := retry(e.HTTPClient)
-	resp, err := e.lb.Send(ctx, &client, Method, e.Endpoints, join(APIPath, name), nil)
+	resp, err := e.lb.Send(ctx, &client, Method, join(APIPath, name), nil)
 	if err != nil {
 		return err
 	}
@@ -396,7 +396,7 @@ func (e *Enclave) GenerateKey(ctx context.Context, name string, context []byte) 
 	}
 
 	client := retry(e.HTTPClient)
-	resp, err := e.lb.Send(ctx, &client, Method, e.Endpoints, join(APIPath, name), bytes.NewReader(body), withHeader("Content-Type", "application/json"))
+	resp, err := e.lb.Send(ctx, &client, Method, join(APIPath, name), bytes.NewReader(body), withHeader("Content-Type", "application/json"))
 	if err != nil {
 		return DEK{}, err
 	}
@@ -446,7 +446,7 @@ func (e *Enclave) Encrypt(ctx context.Context, name string, plaintext, context [
 	}
 
 	client := retry(e.HTTPClient)
-	resp, err := e.lb.Send(ctx, &client, Method, e.Endpoints, join(APIPath, name), bytes.NewReader(body), withHeader("Content-Type", "application/json"))
+	resp, err := e.lb.Send(ctx, &client, Method, join(APIPath, name), bytes.NewReader(body), withHeader("Content-Type", "application/json"))
 	if err != nil {
 		return nil, err
 	}
@@ -495,7 +495,7 @@ func (e *Enclave) Decrypt(ctx context.Context, name string, ciphertext, context 
 	}
 
 	client := retry(e.HTTPClient)
-	resp, err := e.lb.Send(ctx, &client, Method, e.Endpoints, join(APIPath, name), bytes.NewReader(body), withHeader("Content-Type", "application/json"))
+	resp, err := e.lb.Send(ctx, &client, Method, join(APIPath, name), bytes.NewReader(body), withHeader("Content-Type", "application/json"))
 	if err != nil {
 		return nil, err
 	}
@@ -532,7 +532,7 @@ func (e *Enclave) ListKeys(ctx context.Context, prefix string, n int) ([]string,
 	e.init.Do(e.initLoadBalancer)
 
 	client := retry(e.HTTPClient)
-	resp, err := e.lb.Send(ctx, &client, Method, e.Endpoints, join(APIPath, prefix), nil)
+	resp, err := e.lb.Send(ctx, &client, Method, join(APIPath, prefix), nil)
 	if err != nil {
 		return nil, "", err
 	}
@@ -582,7 +582,7 @@ func (e *Enclave) CreateSecret(ctx context.Context, name string, value []byte, o
 	}
 
 	client := retry(e.HTTPClient)
-	resp, err := e.lb.Send(ctx, &client, Method, e.Endpoints, join(APIPath, name), bytes.NewReader(body))
+	resp, err := e.lb.Send(ctx, &client, Method, join(APIPath, name), bytes.NewReader(body))
 	if err != nil {
 		return err
 	}
@@ -614,7 +614,7 @@ func (e *Enclave) DescribeSecret(ctx context.Context, name string) (*SecretInfo,
 	}
 
 	client := retry(e.HTTPClient)
-	resp, err := e.lb.Send(ctx, &client, Method, e.Endpoints, join(APIPath, name), nil)
+	resp, err := e.lb.Send(ctx, &client, Method, join(APIPath, name), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -657,7 +657,7 @@ func (e *Enclave) ReadSecret(ctx context.Context, name string) ([]byte, *SecretI
 	}
 
 	client := retry(e.HTTPClient)
-	resp, err := e.lb.Send(ctx, &client, Method, e.Endpoints, join(APIPath, name), nil)
+	resp, err := e.lb.Send(ctx, &client, Method, join(APIPath, name), nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -691,7 +691,7 @@ func (e *Enclave) DeleteSecret(ctx context.Context, name string) error {
 	e.init.Do(e.initLoadBalancer)
 
 	client := retry(e.HTTPClient)
-	resp, err := e.lb.Send(ctx, &client, Method, e.Endpoints, join(APIPath, name), nil)
+	resp, err := e.lb.Send(ctx, &client, Method, join(APIPath, name), nil)
 	if err != nil {
 		return err
 	}
@@ -722,7 +722,7 @@ func (e *Enclave) ListSecrets(ctx context.Context, prefix string, n int) ([]stri
 	e.init.Do(e.initLoadBalancer)
 
 	client := retry(e.HTTPClient)
-	resp, err := e.lb.Send(ctx, &client, Method, e.Endpoints, join(APIPath, prefix), nil)
+	resp, err := e.lb.Send(ctx, &client, Method, join(APIPath, prefix), nil)
 	if err != nil {
 		return nil, "", err
 	}
@@ -763,7 +763,7 @@ func (e *Enclave) AssignPolicy(ctx context.Context, policy string, identity Iden
 		return err
 	}
 	client := retry(e.HTTPClient)
-	resp, err := e.lb.Send(ctx, &client, Method, e.Endpoints, join(APIPath, policy), bytes.NewReader(body))
+	resp, err := e.lb.Send(ctx, &client, Method, join(APIPath, policy), bytes.NewReader(body))
 	if err != nil {
 		return err
 	}
@@ -791,7 +791,7 @@ func (e *Enclave) CreatePolicy(ctx context.Context, name string, policy *Policy)
 		return err
 	}
 	client := retry(e.HTTPClient)
-	resp, err := e.lb.Send(ctx, &client, Method, e.Endpoints, join(APIPath, name), bytes.NewReader(body), withHeader("Content-Type", "application/json"))
+	resp, err := e.lb.Send(ctx, &client, Method, join(APIPath, name), bytes.NewReader(body), withHeader("Content-Type", "application/json"))
 	if err != nil {
 		return err
 	}
@@ -819,7 +819,7 @@ func (e *Enclave) DescribePolicy(ctx context.Context, name string) (*PolicyInfo,
 		CreatedBy Identity  `json:"created_by"`
 	}
 	client := retry(e.HTTPClient)
-	resp, err := e.lb.Send(ctx, &client, Method, e.Endpoints, join(APIPath, name), nil)
+	resp, err := e.lb.Send(ctx, &client, Method, join(APIPath, name), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -859,7 +859,7 @@ func (e *Enclave) GetPolicy(ctx context.Context, name string) (*Policy, error) {
 		CreatedBy Identity        `json:"created_by"`
 	}
 	client := retry(e.HTTPClient)
-	resp, err := e.lb.Send(ctx, &client, Method, e.Endpoints, join(APIPath, name), nil)
+	resp, err := e.lb.Send(ctx, &client, Method, join(APIPath, name), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -894,7 +894,7 @@ func (e *Enclave) DeletePolicy(ctx context.Context, name string) error {
 	e.init.Do(e.initLoadBalancer)
 
 	client := retry(e.HTTPClient)
-	resp, err := e.lb.Send(ctx, &client, Method, e.Endpoints, join(APIPath, name), nil)
+	resp, err := e.lb.Send(ctx, &client, Method, join(APIPath, name), nil)
 	if err != nil {
 		return err
 	}
@@ -924,7 +924,7 @@ func (e *Enclave) ListPolicies(ctx context.Context, prefix string, n int) ([]str
 	e.init.Do(e.initLoadBalancer)
 
 	client := retry(e.HTTPClient)
-	resp, err := e.lb.Send(ctx, &client, Method, e.Endpoints, join(APIPath, prefix), nil)
+	resp, err := e.lb.Send(ctx, &client, Method, join(APIPath, prefix), nil)
 	if err != nil {
 		return nil, "", err
 	}
@@ -975,7 +975,7 @@ func (e *Enclave) CreateIdentity(ctx context.Context, identity Identity, req *Cr
 	}
 
 	client := retry(e.HTTPClient)
-	resp, err := e.lb.Send(ctx, &client, Method, e.Endpoints, join(APIPath, identity.String()), bytes.NewReader(body))
+	resp, err := e.lb.Send(ctx, &client, Method, join(APIPath, identity.String()), bytes.NewReader(body))
 	if err != nil {
 		return err
 	}
@@ -1008,7 +1008,7 @@ func (e *Enclave) DescribeIdentity(ctx context.Context, identity Identity) (*Ide
 	}
 
 	client := retry(e.HTTPClient)
-	resp, err := e.lb.Send(ctx, &client, Method, e.Endpoints, join(APIPath, identity.String()), nil)
+	resp, err := e.lb.Send(ctx, &client, Method, join(APIPath, identity.String()), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1069,7 +1069,7 @@ func (e *Enclave) DescribeSelf(ctx context.Context) (*IdentityInfo, *Policy, err
 	}
 
 	client := retry(e.HTTPClient)
-	resp, err := e.lb.Send(ctx, &client, Method, e.Endpoints, APIPath, nil)
+	resp, err := e.lb.Send(ctx, &client, Method, APIPath, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1119,7 +1119,7 @@ func (e *Enclave) DeleteIdentity(ctx context.Context, identity Identity) error {
 	e.init.Do(e.initLoadBalancer)
 
 	client := retry(e.HTTPClient)
-	resp, err := e.lb.Send(ctx, &client, Method, e.Endpoints, join(APIPath, identity.String()), nil)
+	resp, err := e.lb.Send(ctx, &client, Method, join(APIPath, identity.String()), nil)
 	if err != nil {
 		return err
 	}
@@ -1149,7 +1149,7 @@ func (e *Enclave) ListIdentities(ctx context.Context, prefix string, n int) ([]I
 	e.init.Do(e.initLoadBalancer)
 
 	client := retry(e.HTTPClient)
-	resp, err := e.lb.Send(ctx, &client, Method, e.Endpoints, join(APIPath, prefix), nil)
+	resp, err := e.lb.Send(ctx, &client, Method, join(APIPath, prefix), nil)
 	if err != nil {
 		return nil, "", err
 	}
@@ -1169,7 +1169,7 @@ func (e *Enclave) ListIdentities(ctx context.Context, prefix string, n int) ([]I
 
 func (e *Enclave) initLoadBalancer() {
 	if e.lb == nil {
-		e.lb = &loadBalancer{endpoints: map[string]time.Time{}}
-		e.lb.enclave = e.Name
+		e.lb = newLoadBalancer(e.Name)
+		e.lb.prepareLoadBalancer(e.Endpoints)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/minio/kes-go
 
-go 1.20
+go 1.21
 
 require (
 	aead.dev/mem v0.2.0

--- a/retry_test.go
+++ b/retry_test.go
@@ -6,10 +6,16 @@ package kes
 
 import (
 	"bytes"
+	"context"
+	"errors"
 	"io"
+	"math/rand"
 	"net"
+	"net/http"
 	"net/url"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 var retryBodyTests = []struct {
@@ -74,6 +80,319 @@ func TestIsNetworkError(t *testing.T) {
 			t.Fatalf("Test %d: err should be a network error but it is not", i)
 		case test.IsNetworkError == false && temp == true:
 			t.Fatalf("Test %d: err should not be a network error but it is", i)
+		}
+	}
+}
+
+type MockResolver struct {
+	DNSRecords map[string][]string
+}
+
+func (m *MockResolver) LookupHost(_ context.Context, host string) (addrs []string, err error) {
+	var ok bool
+	addrs, ok = m.DNSRecords[host]
+	if !ok {
+		return nil, errors.New("Unable to lookup host")
+	}
+	return
+}
+
+func MockSendRequestWithCounter(code int, returnError bool) (*atomic.Uint32, func(ctx context.Context, epr *endpointRequest) (*http.Response, error)) {
+	counter := atomic.Uint32{}
+	return &counter, func(_ context.Context, epr *endpointRequest) (*http.Response, error) {
+		counter.Add(1)
+		if !returnError {
+			resp := new(http.Response)
+			resp.StatusCode = code
+			resp.Proto = epr.addr
+			return resp, nil
+		}
+		return nil, errors.New(epr.addr)
+	}
+}
+
+func MockSendRequest(code int, returnError bool) func(ctx context.Context, epr *endpointRequest) (*http.Response, error) {
+	return func(_ context.Context, epr *endpointRequest) (*http.Response, error) {
+		if !returnError {
+			resp := new(http.Response)
+			resp.StatusCode = code
+			resp.Proto = epr.addr
+			return resp, nil
+		}
+		return nil, errors.New(epr.addr)
+	}
+}
+
+type MockRandomNumber struct {
+	Number int
+}
+
+func (m *MockRandomNumber) Intn(_ int) int {
+	return m.Number
+}
+
+func MockGetInterfaces() (ifs []net.Addr, err error) {
+	ifs, err = net.InterfaceAddrs()
+	if err != nil {
+		return
+	}
+
+	newInterface := new(net.IPNet)
+	newInterface.IP = net.IP{171, 171, 0, 1}
+	newInterface.Mask = net.IPMask{255, 255, 255, 0}
+	ifs = append(ifs, newInterface)
+
+	newInterface2 := new(net.IPNet)
+	newInterface2.IP = net.IP{182, 182, 0, 1}
+	newInterface2.Mask = net.IPMask{255, 255, 255, 0}
+	ifs = append(ifs, newInterface2)
+
+	return
+}
+
+func TestPrepareLoadBalancer(t *testing.T) {
+	Resolver := new(MockResolver)
+	Resolver.DNSRecords = make(map[string][]string)
+	Resolver.DNSRecords["minio.remote"] = []string{"1.1.1.1", "8.8.8.8"}
+	Resolver.DNSRecords["minio.remote2"] = []string{"123.121.123.13", "123.121.123.12", "123.121.123.15"}
+	Resolver.DNSRecords["minio.remote3"] = []string{"8e6e:dd85:041c:5e77:4f44:3484:c050:be7e"}
+	Resolver.DNSRecords["minio.local"] = []string{"127.0.0.1"}
+	Resolver.DNSRecords["minio.local2"] = []string{"171.171.0.10", "171.171.0.11"}
+	Resolver.DNSRecords["minio.local3"] = []string{"182.182.0.10", "182.182.0.11"}
+
+	lb := &loadBalancer{
+		enclave:          "",
+		DNSResolver:      Resolver,
+		getLocalNetworks: MockGetInterfaces,
+		rand:             rand.New(rand.NewSource(time.Now().UnixNano())),
+	}
+
+	dnsErrorEndpoint := "https://minio.404:7373"
+	endpoints := []string{
+		dnsErrorEndpoint,
+		"https://127.0.0.1:7373",
+		"https://localhost:7373",
+		"https://minio.local:7373",
+		"https://minio.local2:7373",
+		"https://minio.local3:7373",
+		"https://minio.remote:7373",
+		"https://minio.remote2:7373",
+		"https://minio.remote3:7373",
+	}
+
+	lb.prepareLoadBalancer(endpoints)
+	notFoundInList := false
+	for i, v := range lb.endpoints {
+		if v.addr == dnsErrorEndpoint {
+			notFoundInList = true
+		}
+		switch i {
+		case 0, 1, 2:
+			if !v.localhost {
+				t.Fatalf("Expected endpoint at index %d to be localhost: %s", i, v.addr)
+			}
+			if v.local {
+				t.Fatalf("Expected endpoint at index %d to not be local: %s", i, v.addr)
+			}
+		case 3, 4:
+			if v.localhost {
+				t.Fatalf("Expected endpoint at index %d to not be localhost: %s", i, v.addr)
+			}
+			if !v.local {
+				t.Fatalf("Expected endpoint at index %d to be local: %s", i, v.addr)
+			}
+		default:
+			if v.localhost || v.local {
+				t.Fatalf("Expected endpoint at index %d to not be localhost or local: %s", i, v.addr)
+			}
+		}
+	}
+
+	if !notFoundInList {
+		t.Fatalf("minio.404 not found in list.")
+	}
+}
+
+func TestLoadBalancerSend_SingleHost(t *testing.T) {
+	Resolver := new(MockResolver)
+	Resolver.DNSRecords = make(map[string][]string)
+	Resolver.DNSRecords["minio.local"] = []string{"127.0.0.1"}
+
+	lb := &loadBalancer{
+		enclave:          "",
+		DNSResolver:      Resolver,
+		getLocalNetworks: MockGetInterfaces,
+		sendRequest:      MockSendRequest(200, false),
+		rand:             rand.New(rand.NewSource(time.Now().UnixNano())),
+	}
+
+	retryClient := new(retry)
+	ctx := context.Background()
+	path := "/bucket1/object1"
+	method := "POST"
+	var options []requestOption
+
+	endpoints := []string{
+		"https://minio.local:7373",
+	}
+
+	lb.prepareLoadBalancer(endpoints)
+
+	// This test ensures that localhost is prioritized and that
+	// it is not placed in a timed-out state.
+	resp, _ := lb.Send(ctx, retryClient, method, path, nil, options...)
+	if resp.Proto != endpoints[0] {
+		t.Fatalf("Expected response.Proto (%s) to equal endpoint (%s)", resp.Proto, endpoints[0])
+	}
+
+	for _, v := range lb.endpoints {
+		if !v.timeout.IsZero() {
+			t.Fatalf("Endpoint %s was expected to NOT be timed-out", v.addr)
+		}
+	}
+
+	lb.sendRequest = MockSendRequest(0, true)
+	// We do not want to place an endpoint in a timed-out state if
+	// we only have one. This test ensures that a load balancer with
+	// only a single endpoint never places that endpoint in a timed-out state.
+	_, err := lb.Send(ctx, retryClient, method, path, nil, options...)
+	if err == nil {
+		t.Fatalf("Endpoint was expected to return an error")
+	}
+	lb.sendRequest = MockSendRequest(500, false)
+	resp, _ = lb.Send(ctx, retryClient, method, path, nil, options...)
+	if resp.Proto != endpoints[0] {
+		t.Fatalf("Expected response.Proto (%s) to equal endpoint (%s)", resp.Proto, endpoints[0])
+	}
+
+	for _, v := range lb.endpoints {
+		if !v.timeout.IsZero() {
+			t.Fatalf("Endpoint %s was expected to NOT be timed-out", v.addr)
+		}
+	}
+}
+
+func TestLoadBalancerSend_MultiHost(t *testing.T) {
+	Resolver := new(MockResolver)
+	Resolver.DNSRecords = make(map[string][]string)
+	Resolver.DNSRecords["minio.remote"] = []string{"1.1.1.1", "8.8.8.8"}
+	Resolver.DNSRecords["minio.remote2"] = []string{"1.1.1.1", "8.8.8.8"}
+	Resolver.DNSRecords["minio.remote3"] = []string{"1.1.1.1", "8.8.8.8"}
+	Resolver.DNSRecords["minio.remote4"] = []string{"1.1.1.1", "8.8.8.8"}
+	Resolver.DNSRecords["minio.remote5"] = []string{"123.121.123.13", "123.121.123.12", "123.121.123.15"}
+	Resolver.DNSRecords["minio.local"] = []string{"127.0.0.1"}
+
+	lb := &loadBalancer{
+		enclave:          "",
+		DNSResolver:      Resolver,
+		getLocalNetworks: MockGetInterfaces,
+		sendRequest:      MockSendRequest(200, false),
+		rand:             rand.New(rand.NewSource(time.Now().UnixNano())),
+	}
+
+	retryClient := new(retry)
+	ctx := context.Background()
+	path := "/bucket1/object1"
+	method := "POST"
+	var options []requestOption
+
+	endpoints := []string{
+		"https://minio.local:7373",
+		"https://minio.remote:7373",
+		"https://minio.remote2:7373",
+		"https://minio.remote3:7373",
+		"https://minio.remote4:7373",
+		"https://minio.remote5:7373",
+	}
+	lb.prepareLoadBalancer(endpoints)
+
+	// This test will ensure that a localhost endpoint is present
+	// at index 0 and is prioritized during load balancing.
+	resp, _ := lb.Send(ctx, retryClient, method, path, nil, options...)
+	if resp.Proto != endpoints[0] {
+		t.Fatalf("Expected response.Proto (%s) to equal endpoint (%s)", resp.Proto, endpoints[0])
+	}
+
+	endpoints = []string{
+		"https://minio.remote:7373",
+		"https://minio.remote2:7373",
+		"https://minio.remote3:7373",
+		"https://minio.remote4:7373",
+		"https://minio.remote5:7373",
+	}
+	lb.prepareLoadBalancer(endpoints)
+
+	// This test will return a 500 error code for all requests
+	// which places all endpoints into a timed-out state.
+	counter, sendFunc := MockSendRequestWithCounter(500, false)
+	lb.sendRequest = sendFunc
+	_, _ = lb.Send(ctx, retryClient, method, path, nil, options...)
+	for _, v := range lb.endpoints {
+		if v.timeout.IsZero() {
+			t.Fatalf("Endpoint %s was expected to be timed-out", v.addr)
+		}
+	}
+
+	// This test will make a request while all endpoints are
+	// in a timed-out state.
+	// When all endpoints are in a timed-out state, the retry
+	// mechanism kicks in. During a retry all timeouts are ignored
+	// and we should see the number of requests be equal to the
+	// number of endpoints.
+	counter.Store(0)
+	_, _ = lb.Send(ctx, retryClient, method, path, nil, options...)
+	count := counter.Load()
+	if count != 5 {
+		t.Fatalf("Request count expected to be 5 but was %d", count)
+	}
+
+	// This test ensures that status code 501 does not
+	// place the endpoint in a timed-out state.
+	lb.prepareLoadBalancer(endpoints)
+	lb.sendRequest = MockSendRequest(501, false)
+	_, _ = lb.Send(ctx, retryClient, method, path, nil, options...)
+	for _, v := range lb.endpoints {
+		if !v.timeout.IsZero() {
+			t.Fatalf("Endpoint %s was expected to NOT be timed-out", v.addr)
+		}
+	}
+
+	// This test ensures that an error response will
+	// place and endpoint in a timed-out state.
+	lb.prepareLoadBalancer(endpoints)
+	lb.sendRequest = MockSendRequest(0, true)
+	_, _ = lb.Send(ctx, retryClient, method, path, nil, options...)
+	for _, v := range lb.endpoints {
+		if v.timeout.IsZero() {
+			t.Fatalf("Endpoint %s was expected to be timed-out", v.addr)
+		}
+	}
+
+	// This request ensures all endpoints are placed in a timed-out state.
+	lb.prepareLoadBalancer(endpoints)
+	lb.sendRequest = MockSendRequest(0, true)
+	_, _ = lb.Send(ctx, retryClient, method, path, nil, options...)
+
+	// We want to shift the timeout timestamps to a date in the past
+	// in order to trigger probing.
+	for i := range lb.endpoints {
+		lb.endpoints[i].timeout = time.Now().AddDate(0, 0, -1)
+	}
+
+	// This test triggers a probe on all endpoints in order
+	// to clear all timeouts
+	mockRandom := new(MockRandomNumber)
+	lb.rand = mockRandom
+	mockRandom.Number = 0
+	lb.sendRequest = MockSendRequest(200, false)
+	for i := 0; i < len(endpoints); i++ {
+		_, _ = lb.Send(ctx, retryClient, method, path, nil, options...)
+		mockRandom.Number++
+	}
+
+	for _, v := range lb.endpoints {
+		if !v.timeout.IsZero() {
+			t.Fatalf("Endpoint %s was expected to NOT be timed-out", v.addr)
 		}
 	}
 }


### PR DESCRIPTION
The original idea was to add the ability to prioritize localhost above other hosts when sending requests to KES instances, but in order to accomplish that goal, a refactor of the load balancer was required. 

Since the load balancer is a crucial component across the minio ecosystem some tests seemed appropriate, hence a few methods were abstracted in order to create mocks. 

The current changes to the load balancer are designed in a way to not require updates in other components of the minio ecosystem. However, I do plan on making some future revisions to this repository and related components.

# How the new load balancing works
1. If there is only one endpoint, it will be used and the load balancing mechanism ignored
2. If there is a localhost endpoint, then it will be prioritized but.
3. If there is no localhost endpoint or the localhost endpoint is in a timed-out state, we will iterate through endpoints in a random manner.
4. Before sending requests to an endpoint it's timed-out state is checked, if the timeout has passed 30 seconds a probe will be initiated.
5. If the request is successful the endpoint is marked as active again, otherwise the timeout is extended by 30 seconds.
6. If there are no active endpoints, the retry mechanism will do another iteration on endpoint while ignoring timeouts.
7. Endpoints are only marked as active again when requests are in a probe or ignore-timeout state.  

# Future updates
## Removing the enclave
@aead and I had a discussion about kes and future plans about removing the enclave concept. This will also opens an opportunity to simplify the initialization process for the Client and loadBalancer.
## Prefering endpoints on local networks over remote endpoints
Currently the endpoints are sorted by network location: Localhost < Local Network < Remote Network. However, the load balancer is not distinguishing between endpoints on local networks and endpoint on remote networks. This is an update that can be made in the future. For now we just wanted to get priority on localhost.  

# How to test
```bash
go clean -testcache && go test -v -run .
``` 

 