### PR TITLE
fix argument order in `policy.Verify`

### DIFF
--- a/policy.go
+++ b/policy.go
@@ -64,12 +64,12 @@ type Policy struct {
 // Otherwise, Verify returns ErrNotAllowed.
 func (p *Policy) Verify(r *http.Request) error {
 	for pattern := range p.Deny {
-		if match(r.URL.Path, pattern) {
+		if match(pattern, r.URL.Path) {
 			return ErrNotAllowed
 		}
 	}
 	for pattern := range p.Allow {
-		if match(r.URL.Path, pattern) {
+		if match(pattern, r.URL.Path) {
 			return nil
 		}
 	}


### PR DESCRIPTION
This commit fixes a bug in the `policy.Verify` function. The order of the arguments was incorrect causing `Verify` to behave incorrectly.

This commit also adds some test cases to test this behavior.