### PR TITLE
kms: fix bug in `Client.Encrypt`

### DIFF
--- a/kms/client.go
+++ b/kms/client.go
@@ -1170,7 +1170,7 @@ func (c *Client) Encrypt(ctx context.Context, enclave string, reqs ...*EncryptRe
 	}
 	defer resp.Body.Close()
 
-	return decodeResponse[pb.EncryptResponse, EncryptResponse](resp, cmds.KeyStatus)
+	return decodeResponse[pb.EncryptResponse, EncryptResponse](resp, cmds.KeyEncrypt)
 }
 
 // Decrypt decrypts the req.Ciphertext with the key req.Name within


### PR DESCRIPTION
This commit fixes a bug in the `Client.Encrypt` implementation. The implementation used the wrong command to parse the response.