### PR TITLE
Fix issue when client is used with APIKey

### DIFF
--- a/kms/client.go
+++ b/kms/client.go
@@ -64,12 +64,22 @@ func NewClient(conf *Config) (*Client, error) {
 		return nil, errors.New("kms: invalid config: 'APIKey' and 'TLS.GetClientCertificate' are present")
 	}
 
-	tlsConf := conf.TLS.Clone()
+	tlsConf := conf.TLS
 	if conf.APIKey != nil {
 		cert, err := GenerateCertificate(conf.APIKey, nil)
 		if err != nil {
 			return nil, err
 		}
+
+		// ensure that the TLS configuration is not nil and
+		// the TLS configuration is cloned to avoid
+		// modifying the original TLS configuration.
+		if tlsConf == nil {
+			tlsConf = &tls.Config{}
+		} else {
+			tlsConf = tlsConf.Clone()
+		}
+
 		tlsConf.GetClientCertificate = func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
 			return &cert, nil
 		}


### PR DESCRIPTION
This PR fixes two issues:
1. Panic when using `APIKey` and no TLS configuration.
2. No need to clone TLS configuration when no `APIKey` is used.