### PR TITLE
kms: add `Client.Restart` and `RestartRequest`

### DIFF
--- a/kms/internal/api/api.go
+++ b/kms/internal/api/api.go
@@ -14,9 +14,7 @@ const (
 	PathHealthLive  = "/v1/health/live"  // Unprivileged by default - liveness check
 	PathHealthReady = "/v1/health/ready" // Unprivileged by default - readiness check
 
-	PathHealthStatus = "/v1/health/status"
-	PathHealthAPIs   = "/v1/health/api"
-
+	PathRestart = "/v1/debug/restart"
 	PathProfile = "/v1/debug/pprof"
 	PathLog     = "/v1/debug/log"
 

--- a/kms/request.go
+++ b/kms/request.go
@@ -127,6 +127,14 @@ type ReadinessRequest struct {
 	Write bool
 }
 
+// RestartRequest contains options for restarting
+// one or multiple KMS servers.
+type RestartRequest struct {
+	// List of endpoints which get restarted. If empty,
+	// the client restarts all known servers.
+	Hosts []string
+}
+
 // ServerStatusRequest contains options for fetching status
 // information for one particular KMS server.
 type ServerStatusRequest struct {


### PR DESCRIPTION
This commit adds the `Client.Restart` method that
allows clients to restart one or multiple KMS servers.