### PR TITLE
kms: extend the `Client.Restart` API to support cluster-wide restarts

### DIFF
--- a/kms/internal/api/api.go
+++ b/kms/internal/api/api.go
@@ -29,5 +29,6 @@ const (
 
 // API query parameters supported by KMS servers.
 const (
-	QueryReadyWrite = "write"
+	QueryReadyWrite  = "write"
+	QueryRestartSelf = "self"
 )


### PR DESCRIPTION
This commit changes the behavior of `Client.Restart` such that it uses the cluster-wide restart mechanism to restart all nodes within a cluster.

The adv. of the new cluster-wide restart is that a client doesn't have to know all cluster nodes to restart all nodes within a cluster. Instead, it can delegate this task to one of the cluster nodes.

However, a client can still restart all cluster nodes itself by providing a list of hosts.